### PR TITLE
Ensure single H1 per page in components

### DIFF
--- a/components/HeroImage.vue
+++ b/components/HeroImage.vue
@@ -7,12 +7,7 @@
       :max-height="400"
       class="hero-image"
     >
-      <v-sheet
-        width="100%"
-        height="100%"
-        color="transparent"
-        class="text-h5 text-sm-h3 text-md-h2 text-white"
-      >
+      <v-sheet width="100%" height="100%" color="transparent">
         <v-container fluid class="h-100 ps-4 ps-md-12 pb-0">
           <v-row class="h-100">
             <v-col
@@ -21,15 +16,21 @@
               cols="12"
               md="10"
             >
-              <p class="font-weight-bold">{{ heroText }}</p>
+              <h1
+                class="text-h5 text-sm-h3 text-md-h2 text-white font-weight-bold"
+              >
+                {{ heroText }}
+              </h1>
             </v-col>
 
             <v-col v-else class="d-flex flex-column justify-end pb-0 pb-md-4">
-              <p class="font-weight-bold">Natasha & Sophie</p>
-              <p class="font-weight-thin">
-                Independent Midwives<br />
-                in Kent
-              </p>
+              <h1 class="text-h5 text-sm-h3 text-md-h2 text-white">
+                <p class="font-weight-bold">Natasha & Sophie</p>
+                <p class="font-weight-thin">
+                  Independent Midwives<br />
+                  in Kent
+                </p>
+              </h1>
             </v-col>
           </v-row>
         </v-container>

--- a/components/blocks/FAQ.vue
+++ b/components/blocks/FAQ.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="centered ? 'text-center' : ''">
-    <h1 class="text-h5 font-weight-bold mb-4">{{ title }}</h1>
+    <h2 class="text-h5 font-weight-bold mb-4">{{ title }}</h2>
     <SanityContent :blocks="body" :serializers="serializers" />
   </div>
 </template>

--- a/components/blocks/LogoGroup.vue
+++ b/components/blocks/LogoGroup.vue
@@ -2,7 +2,7 @@
   <v-container>
     <v-row v-if="title">
       <v-col>
-        <h1 class="text-h4 font-weight-bold">{{ title }}</h1>
+        <h2 class="text-h4 font-weight-bold">{{ title }}</h2>
       </v-col>
     </v-row>
 


### PR DESCRIPTION
Demote heading levels in the HeroImage, FAQ, and LogoGroup components to maintain a single H1 per page structure. This change improves accessibility and SEO compliance.