### PR TITLE
feat: add Recent Blog Posts page builder block

### DIFF
--- a/components/PageBuilder.vue
+++ b/components/PageBuilder.vue
@@ -21,6 +21,7 @@ import CTA from "./blocks/CTA.vue";
 import Image from "./blocks/Image.vue";
 import Recommendation from "./blocks/Recommendation.vue";
 import Calendly from "./blocks/Calendly.vue";
+import RecentPosts from "./blocks/RecentPosts.vue";
 
 defineProps({
   blocks: {
@@ -38,5 +39,6 @@ const components: Record<string, Component> = {
   centeredImage: Image,
   recommendation: Recommendation,
   calendly: Calendly,
+  recentPosts: RecentPosts,
 };
 </script>

--- a/components/blocks/RecentPosts.vue
+++ b/components/blocks/RecentPosts.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-container>
+    <h2 v-if="heading" class="text-h5 font-weight-bold mb-8">{{ heading }}</h2>
+
+    <v-row>
+      <v-col
+        cols="12"
+        sm="4"
+        v-for="post in displayPosts"
+        :key="post._id"
+        class="d-flex"
+      >
+        <v-card flat class="d-flex w-100">
+          <v-card-text class="d-flex flex-column justify-space-between">
+            <div>
+              <NuxtLink v-if="post.image" :to="`/blog/${post.slug?.current}`">
+                <v-img
+                  :src="$urlFor(post.image).url()"
+                  cover
+                  width="100%"
+                  :max-height="200"
+                  aspect-ratio="1"
+                  rounded="lg"
+                  class="mb-2"
+                />
+              </NuxtLink>
+
+              <NuxtLink
+                :to="`/blog/${post.slug?.current}`"
+                class="text-h6 line-height-1 font-weight-bold text-surface-variant text-decoration-none"
+              >
+                {{ post.title }}
+              </NuxtLink>
+            </div>
+
+            <NuxtLink
+              :to="`/blog/${post.slug?.current}`"
+              class="text-body-1 mt-2"
+            >
+              Read more
+            </NuxtLink>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import type { SanityDocument } from "@sanity/client";
+
+const props = defineProps({
+  heading: {
+    type: String,
+    default: "",
+  },
+  posts: {
+    type: Array as () => SanityDocument[],
+    default: () => [],
+  },
+  fallbackPosts: {
+    type: Array as () => SanityDocument[],
+    default: () => [],
+  },
+});
+
+const displayPosts = computed(() =>
+  props.posts?.length ? props.posts : props.fallbackPosts,
+);
+</script>
+
+<style scoped>
+.line-height-1 {
+  line-height: 1.1rem !important;
+}
+</style>

--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -26,6 +26,11 @@ const PAGE_QUERY = groq`*[_type == "page" && slug.current == '${route.params.slu
         internalLink->,
       }
     },
+    _type == "recentPosts" => {
+      ...,
+      posts[]->
+    },
+    "fallbackPosts": select(_type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]),
     body[]{
       ...,
       markDefs[]{

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -91,6 +91,11 @@ const SITE_QUERY = groq`*[_id == "siteSettings"][0]{
         internalLink->,
       },
       internalLink->,
+      _type == "recentPosts" => {
+        ...,
+        posts[]->
+      },
+      "fallbackPosts": select(_type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]),
       body[]{
         ...,
         markDefs[]{


### PR DESCRIPTION
## Summary
- Adds a `RecentPosts` Vue block component that displays 3 blog posts
- If no posts are manually selected, falls back to the 3 most recent blogs via a GROQ `select()` sub-query
- GROQ queries updated in both `index.vue` and `[slug].vue` to support the new block

## Test plan
- [ ] Add a Recent Blog Posts block to the homepage in Sanity without selecting any posts — should show the 3 most recent
- [ ] Add a Recent Blog Posts block and select specific posts — should show only those posts
- [ ] Verify block saves correctly in Sanity when no posts are selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)