### PR TITLE
feat: extend Recent Posts block to support birth stories

### DIFF
--- a/components/blocks/RecentPosts.vue
+++ b/components/blocks/RecentPosts.vue
@@ -13,7 +13,7 @@
         <v-card flat class="d-flex w-100">
           <v-card-text class="d-flex flex-column justify-space-between">
             <div>
-              <NuxtLink v-if="post.image" :to="`/blog/${post.slug?.current}`">
+              <NuxtLink v-if="post.image" :to="`${postBasePath}/${post.slug?.current}`">
                 <v-img
                   :src="$urlFor(post.image).url()"
                   cover
@@ -26,7 +26,7 @@
               </NuxtLink>
 
               <NuxtLink
-                :to="`/blog/${post.slug?.current}`"
+                :to="`${postBasePath}/${post.slug?.current}`"
                 class="text-h6 line-height-1 font-weight-bold text-surface-variant text-decoration-none"
               >
                 {{ post.title }}
@@ -34,7 +34,7 @@
             </div>
 
             <NuxtLink
-              :to="`/blog/${post.slug?.current}`"
+              :to="`${postBasePath}/${post.slug?.current}`"
               class="text-body-1 mt-2"
             >
               Read more
@@ -54,7 +54,15 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  postType: {
+    type: String,
+    default: "blog",
+  },
   posts: {
+    type: Array as () => SanityDocument[],
+    default: () => [],
+  },
+  birthStoryPosts: {
     type: Array as () => SanityDocument[],
     default: () => [],
   },
@@ -64,8 +72,16 @@ const props = defineProps({
   },
 });
 
+const postBasePath = computed(() =>
+  props.postType === "birthStory" ? "/birth-stories" : "/blog",
+);
+
+const selectedPosts = computed(() =>
+  props.postType === "birthStory" ? props.birthStoryPosts : props.posts,
+);
+
 const displayPosts = computed(() =>
-  props.posts?.length ? props.posts : props.fallbackPosts,
+  selectedPosts.value?.length ? selectedPosts.value : props.fallbackPosts,
 );
 </script>
 

--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -28,9 +28,13 @@ const PAGE_QUERY = groq`*[_type == "page" && slug.current == '${route.params.slu
     },
     _type == "recentPosts" => {
       ...,
-      posts[]->
+      posts[]->,
+      birthStoryPosts[]->
     },
-    "fallbackPosts": select(_type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]),
+    "fallbackPosts": select(
+      _type == "recentPosts" && postType == "birthStory" => *[_type == "birthStory"] | order(publishedAt desc) [0..2],
+      _type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]
+    ),
     body[]{
       ...,
       markDefs[]{

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -93,9 +93,13 @@ const SITE_QUERY = groq`*[_id == "siteSettings"][0]{
       internalLink->,
       _type == "recentPosts" => {
         ...,
-        posts[]->
+        posts[]->,
+        birthStoryPosts[]->
       },
-      "fallbackPosts": select(_type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]),
+      "fallbackPosts": select(
+        _type == "recentPosts" && postType == "birthStory" => *[_type == "birthStory"] | order(publishedAt desc) [0..2],
+        _type == "recentPosts" => *[_type == "blog"] | order(publishedAt desc) [0..2]
+      ),
       body[]{
         ...,
         markDefs[]{


### PR DESCRIPTION
## Summary
- Adds a `postType` radio toggle (Blog Posts / Birth Stories) to the `recentPosts` page builder block
- Conditionally shows the relevant reference array based on the toggle
- Updates GROQ queries in `index.vue` and `[slug].vue` to dereference `birthStoryPosts` and fall back to the correct content type
- Routes birth story links to `/birth-stories` and blog links to `/blog`

## Test plan
- [ ] Add a Recent Posts block to a page in the CMS and toggle between Blog Posts and Birth Stories — correct reference field should show/hide
- [ ] Leave references empty — fallback should show 3 most recent posts of the selected type
- [ ] Verify blog links resolve to `/blog/[slug]`
- [ ] Verify birth story links resolve to `/birth-stories/[slug]` (note: detail pages not yet built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)