### PR TITLE
feat: add Travel Radius Map page builder block

### DIFF
--- a/components/PageBuilder.vue
+++ b/components/PageBuilder.vue
@@ -21,6 +21,7 @@ import CTA from "./blocks/CTA.vue";
 import Image from "./blocks/Image.vue";
 import Recommendation from "./blocks/Recommendation.vue";
 import Calendly from "./blocks/Calendly.vue";
+import TravelRadiusMap from "./blocks/TravelRadiusMap.vue";
 
 defineProps({
   blocks: {
@@ -38,5 +39,6 @@ const components: Record<string, Component> = {
   centeredImage: Image,
   recommendation: Recommendation,
   calendly: Calendly,
+  travelRadiusMap: TravelRadiusMap,
 };
 </script>

--- a/components/blocks/TravelRadiusMap.vue
+++ b/components/blocks/TravelRadiusMap.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12" class="py-8" style="height: 600px">
+        <h2 v-if="title" class="text-h5 font-weight-bold mb-4">{{ title }}</h2>
+        <div ref="mapContainer" style="width: 100%; height: 500px"></div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { setOptions, importLibrary } from "@googlemaps/js-api-loader";
+
+const props = defineProps<{
+  title?: string;
+  center: { lat: number; lng: number };
+  radius: number;
+}>();
+
+const mapContainer = ref<HTMLElement | null>(null);
+const config = useRuntimeConfig();
+
+onMounted(async () => {
+  setOptions({
+    key: config.public.GOOGLE_MAPS_API_KEY as string,
+  });
+
+  const { Map, Circle } = await importLibrary("maps");
+
+  const center = { lat: props.center.lat, lng: props.center.lng };
+  const radiusMeters = props.radius * 1000;
+
+  const map = new Map(mapContainer.value!, {
+    center,
+    zoom: 8,
+    mapTypeId: "roadmap",
+    disableDefaultUI: false,
+  });
+
+  new Circle({
+    map,
+    center,
+    radius: radiusMeters,
+    strokeColor: "#6750A4",
+    strokeOpacity: 0.8,
+    strokeWeight: 2,
+    fillColor: "#6750A4",
+    fillOpacity: 0.15,
+  });
+});
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,6 +71,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
+      GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY || "",
       SENTRY_DSN_PUBLIC: process.env.SENTRY_DSN_PUBLIC || "",
       SENTRY_TRACES_SAMPLE_RATE:
         process.env.NODE_ENV === "production" ? 1 : 0.1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
         "@mdi/font": "^7.4.47",
         "@nuxt/image": "1.10.0",
         "@nuxtjs/google-fonts": "3.2.0",
@@ -26,6 +27,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@types/google.maps": "^3.58.1",
         "sass": "^1.85.1",
         "sass-loader": "^16.0.5",
         "vite-plugin-vuetify": "^2.1.0",
@@ -950,6 +952,15 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
     },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
@@ -4278,6 +4289,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "2.3.10",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@googlemaps/js-api-loader": "^2.0.2",
     "@mdi/font": "^7.4.47",
     "@nuxt/image": "1.10.0",
     "@nuxtjs/google-fonts": "3.2.0",
@@ -29,6 +30,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@types/google.maps": "^3.58.1",
     "sass": "^1.85.1",
     "sass-loader": "^16.0.5",
     "vite-plugin-vuetify": "^2.1.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -63,8 +63,10 @@
             max-width="500"
             @click:append-inner="submit"
             :rules="[
-              (v: any) => !!v || 'Email is required', 
-              (v: any) => v.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/) || 'Invalid email address'
+              (v: any) => !!v || 'Email is required',
+              (v: any) =>
+                v.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/) ||
+                'Invalid email address',
             ]"
             ref="emailInput"
           />
@@ -76,6 +78,7 @@
 </template>
 
 <script setup lang="ts">
+import TravelRadiusMap from "../components/blocks/TravelRadiusMap.vue";
 import type { SanityDocument } from "@sanity/client";
 
 const { setHeroText } = useHero();


### PR DESCRIPTION
## Summary
- Adds `TravelRadiusMap.vue` block component driven by CMS data (title, center coordinates, radius)
- Registers block in `PageBuilder.vue` under the `travelRadiusMap` type
- Adds `@googlemaps/js-api-loader` dependency and exposes `GOOGLE_MAPS_API_KEY` via runtime config

## Test plan
- [ ] Add a Travel Radius Map block to a page in Sanity and verify it renders correctly
- [ ] Confirm the circle radius scales correctly from the km value set in the CMS
- [ ] Check the map renders on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)