### PR TITLE
fix: include page type prefix in internal link URLs for CTA and ImageText blocks

### DIFF
--- a/components/blocks/CTA.vue
+++ b/components/blocks/CTA.vue
@@ -43,10 +43,22 @@ const url = computed(() => {
   return {};
 });
 
+function getPrefix(pageType: string) {
+  switch (pageType) {
+    case "blog":
+      return "/blog/";
+    case "birthStory":
+      return "/birth-stories/";
+    default:
+      return "/";
+  }
+}
+
 function linkUrl(link: any) {
   if (link.type === "internal") {
-    let url = "/" + link.internalLink?.slug?.current;
-    if (link.anchor) url += link.anchor;
+    const prefix = getPrefix(link.internalLink?._type);
+    let url = `${prefix}${link.internalLink?.slug?.current}`;
+    if (link.anchor) url += `#${link.anchor}`;
     return { to: url };
   }
   return { href: link.url };

--- a/components/blocks/ImageText.vue
+++ b/components/blocks/ImageText.vue
@@ -89,9 +89,21 @@ const serializers = {
   },
 };
 
+function getPrefix(pageType: string) {
+  switch (pageType) {
+    case "blog":
+      return "/blog/";
+    case "birthStory":
+      return "/birth-stories/";
+    default:
+      return "/";
+  }
+}
+
 const url = computed(() => {
   if (props.link.type === "internal") {
-    let url = props.link.internalLink.slug.current;
+    const prefix = getPrefix(props.link.internalLink?._type);
+    let url = `${prefix}${props.link.internalLink.slug.current}`;
     if (props.link.anchor) url += `#${props.link.anchor}`;
     return url;
   }


### PR DESCRIPTION
## Summary

- CTA and ImageText blocks were building internal links using only the slug, missing the `/blog/` and `/birth-stories/` prefixes
- This caused 404s when linking to blog posts or birth stories from those blocks
- Fixed both components to use `_type` to determine the correct path prefix, matching the existing logic in `plugins/sanity.ts`

## Test plan

- [ ] Add a CTA block inside a blog post with an internal link to another blog post — confirm the URL includes `/blog/`
- [ ] Add an ImageText block with an internal link to a blog post — confirm the URL includes `/blog/`
- [ ] Verify links to regular pages still resolve correctly (no double slash or missing prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)