### PR TITLE
feat: wire CMS SEO fields into page meta tags

### DIFF
--- a/pages/[slug].vue
+++ b/pages/[slug].vue
@@ -62,7 +62,15 @@ if (!data.value?._id) {
 
 setHeroText(data.value?.title);
 
+const nuxtApp = useNuxtApp();
 useSeoMeta({
-  title: () => `${data.value?.title} | Juno Midwives` || "Juno Midwives",
+  title: () => `${data.value?.seo?.metaTitle || data.value?.title} | Juno Midwives`,
+  description: () => data.value?.seo?.metaDescription,
+  ogTitle: () => data.value?.seo?.metaTitle || data.value?.title,
+  ogDescription: () => data.value?.seo?.metaDescription,
+  ogImage: () => {
+    const img = data.value?.seo?.ogImage;
+    return img ? (nuxtApp as any).$urlFor(img).width(1200).height(630).url() : undefined;
+  },
 });
 </script>

--- a/pages/birth-stories/[slug].vue
+++ b/pages/birth-stories/[slug].vue
@@ -70,8 +70,16 @@ const { birthStory, birthStories } = storeToRefs(useBirthStoriesStore());
 await getBirthStories();
 await getBirthStory(route.params.slug as string);
 
+const nuxtApp = useNuxtApp();
 useSeoMeta({
-  title: () => `${birthStory.value?.title} | Juno Midwives` || "Juno Midwives",
+  title: () => `${birthStory.value?.seo?.metaTitle || birthStory.value?.title} | Juno Midwives`,
+  description: () => birthStory.value?.seo?.metaDescription,
+  ogTitle: () => birthStory.value?.seo?.metaTitle || birthStory.value?.title,
+  ogDescription: () => birthStory.value?.seo?.metaDescription,
+  ogImage: () => {
+    const img = birthStory.value?.seo?.ogImage;
+    return img ? (nuxtApp as any).$urlFor(img).width(1200).height(630).url() : undefined;
+  },
 });
 
 const prevousBirthStory = computed(() => {

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -70,8 +70,16 @@ const { setHeroText } = useHero();
 const { getBlog, getBlogs } = useBlogStore();
 const { blog, blogs } = storeToRefs(useBlogStore());
 
+const nuxtApp = useNuxtApp();
 useSeoMeta({
-  title: () => `${blog.value?.title} | Juno Midwives` || "Juno Midwives",
+  title: () => `${blog.value?.seo?.metaTitle || blog.value?.title} | Juno Midwives`,
+  description: () => blog.value?.seo?.metaDescription,
+  ogTitle: () => blog.value?.seo?.metaTitle || blog.value?.title,
+  ogDescription: () => blog.value?.seo?.metaDescription,
+  ogImage: () => {
+    const img = blog.value?.seo?.ogImage;
+    return img ? (nuxtApp as any).$urlFor(img).width(1200).height(630).url() : undefined;
+  },
 });
 
 await getBlogs();

--- a/pages/contact-us.vue
+++ b/pages/contact-us.vue
@@ -112,11 +112,24 @@
 </template>
 
 <script setup lang="ts">
+import type { SanityDocument } from "@sanity/client";
+
 const { setHeroText } = useHero();
 setHeroText("Contact Us");
 
+const SEO_QUERY = groq`*[_id == "staticPageSeo"][0].contact`;
+const { data: seo } = await useSanityQuery<SanityDocument>(SEO_QUERY);
+
+const nuxtApp = useNuxtApp();
 useSeoMeta({
-  title: "Contact Us | Juno Midwives",
+  title: () => `${seo.value?.metaTitle || "Contact Us"} | Juno Midwives`,
+  description: () => seo.value?.metaDescription,
+  ogTitle: () => seo.value?.metaTitle || "Contact Us",
+  ogDescription: () => seo.value?.metaDescription,
+  ogImage: () => {
+    const img = seo.value?.ogImage;
+    return img ? (nuxtApp as any).$urlFor(img).width(1200).height(630).url() : undefined;
+  },
 });
 
 const form = ref<HTMLFormElement>();

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -118,6 +118,18 @@ const SITE_QUERY = groq`*[_id == "siteSettings"][0]{
 }`;
 const { data } = await useSanityQuery<SanityDocument>(SITE_QUERY);
 
+const nuxtApp = useNuxtApp();
+useSeoMeta({
+  title: () => data.value?.homePage?.seo?.metaTitle || "Juno Midwives",
+  description: () => data.value?.homePage?.seo?.metaDescription,
+  ogTitle: () => data.value?.homePage?.seo?.metaTitle || "Juno Midwives",
+  ogDescription: () => data.value?.homePage?.seo?.metaDescription,
+  ogImage: () => {
+    const img = data.value?.homePage?.seo?.ogImage;
+    return img ? (nuxtApp as any).$urlFor(img).width(1200).height(630).url() : undefined;
+  },
+});
+
 const { subscribe } = useNewsletterStore();
 const { name, email } = storeToRefs(useNewsletterStore());
 


### PR DESCRIPTION
## Summary

- CMS-driven pages (dynamic `[slug].vue`, blog posts, birth stories) now read `metaTitle`, `metaDescription`, and `ogImage` from the `seo` field added to those Sanity document types, falling back to the page title when not set
- Homepage uses `homePage.seo` from the siteSettings query (already fetched via `...` spread)
- Contact page fetches from the `staticPageSeo` singleton introduced in junomidwives/cms#13
- OG images are generated via `$urlFor` at 1200×630 (standard OG size); falls back to the app-level default in `app.vue` when not set

## Test plan

- [ ] Open a blog post in the browser, inspect `<head>` — verify `<title>`, `meta[name=description]`, `og:title`, `og:description` reflect CMS values (or fall back to page title)
- [ ] Same check for a birth story and a dynamic page
- [ ] Set a custom `metaTitle` / `metaDescription` in the CMS for a blog post and verify they appear in `<head>`
- [ ] Upload an `ogImage` in the CMS for a page and verify `og:image` resolves to a Sanity CDN URL
- [ ] Verify the contact page meta reflects the `staticPageSeo.contact` singleton values
- [ ] Verify pages with no CMS SEO fields still render sensible fallback titles

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)