### PR TITLE
fix: change banner heading from h1 to p

### DIFF
--- a/components/HeroImage.vue
+++ b/components/HeroImage.vue
@@ -16,21 +16,21 @@
               cols="12"
               md="10"
             >
-              <h1
+              <p
                 class="text-h5 text-sm-h3 text-md-h2 text-white font-weight-bold"
               >
                 {{ heroText }}
-              </h1>
+              </p>
             </v-col>
 
             <v-col v-else class="d-flex flex-column justify-end pb-0 pb-md-4">
-              <h1 class="text-h5 text-sm-h3 text-md-h2 text-white">
+              <div class="text-h5 text-sm-h3 text-md-h2 text-white">
                 <p class="font-weight-bold">Natasha & Sophie</p>
                 <p class="font-weight-thin">
                   Independent Midwives<br />
                   in Kent
                 </p>
-              </h1>
+              </div>
             </v-col>
           </v-row>
         </v-container>


### PR DESCRIPTION
## Summary
- Changes the banner heading element from `<h1>` to `<p>` on inner pages
- Replaces the home page banner `<h1>` wrapper with a `<div>` (the inner `<p>` elements remain unchanged)
- Vuetify typography classes are preserved so visual appearance is unchanged

Closes #21

## Test plan
- [x] Visit homepage — banner text ("Natasha & Sophie / Independent Midwives in Kent") looks identical
- [x] Visit an inner page (e.g. Services) — banner heading looks identical
- [x] Confirm no `<h1>` exists in the banner via browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)