### PR TITLE
feat: dynamically balance LogoGroup grid for any logo count

### DIFF
--- a/components/blocks/LogoGroup.vue
+++ b/components/blocks/LogoGroup.vue
@@ -7,8 +7,13 @@
     </v-row>
 
     <v-container>
-      <v-row>
-        <v-col cols="6" md="4" lg="3" v-for="logo in logos">
+      <v-row justify="center">
+        <v-col
+          cols="6"
+          :md="mdColWidth"
+          v-for="logo in logos"
+          class="d-flex justify-center"
+        >
           <nuxt-link :href="logo.url" target="_blank">
             <v-img
               :src="$urlFor(logo.image).url()"
@@ -24,10 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { useDisplay } from "vuetify";
-const { xs } = useDisplay();
-
-defineProps({
+const props = defineProps({
   title: {
     type: String,
     default: "",
@@ -36,5 +38,13 @@ defineProps({
     type: Array as () => any[],
     default: () => [],
   },
+});
+
+const mdColWidth = computed(() => {
+  const n = props.logos.length;
+  for (const perRow of [3, 4, 2, 6]) {
+    if (n % perRow === 0) return 12 / perRow;
+  }
+  return 4;
 });
 </script>


### PR DESCRIPTION
Closes #19

## Summary
- Replaces the fixed `lg="3"` column width with a computed `mdColWidth` that finds the most even row distribution for however many logos are in the CMS (tries 3, 4, 2, or 6 per row; falls back to 3)
- Adds `justify="center"` to the row and `d-flex justify-center` to each col so partial last rows are centred rather than left-aligned
- Removes unused `useDisplay` import

## Test plan
- [ ] Verify 6 logos render as 3+3 on desktop
- [ ] Test with other logo counts (4, 5, 8) in the CMS to confirm even distribution
- [ ] Check mobile layout still shows 2 per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)