### PR TITLE
fix: prevent set -e from killing release workflow on empty PR categories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
             local items
             items=$(echo "$PRS" | jq -r --arg p "$prefix" \
               '.[] | select(.title | test("^" + $p + "\\b"; "i")) | "- \(.title) (#\(.number))"')
-            [ -n "$items" ] && printf "## %s\n%s\n\n" "$heading" "$items"
+            if [ -n "$items" ]; then
+              printf "## %s\n%s\n\n" "$heading" "$items"
+            fi
           }
 
           NOTES_FILE=$(mktemp)
@@ -67,7 +69,9 @@ jobs:
             KNOWN="feat|fix|chore|docs|refactor|perf|style|test|ci|build"
             OTHERS=$(echo "$PRS" | jq -r --arg p "$KNOWN" \
               '.[] | select(.title | test("^(" + $p + ")\\b"; "i") | not) | "- \(.title) (#\(.number))"')
-            [ -n "$OTHERS" ] && printf "## Other Changes\n%s\n" "$OTHERS"
+            if [ -n "$OTHERS" ]; then
+              printf "## Other Changes\n%s\n" "$OTHERS"
+            fi
           } > "$NOTES_FILE"
 
           gh release create "$VERSION" \
@@ -114,7 +118,9 @@ jobs:
             local items
             items=$(echo "$PRS" | jq -r --arg p "$prefix" \
               '.[] | select(.title | test("^" + $p + "\\b"; "i")) | "- \(.title) (#\(.number))"')
-            [ -n "$items" ] && printf "## %s\n%s\n\n" "$heading" "$items"
+            if [ -n "$items" ]; then
+              printf "## %s\n%s\n\n" "$heading" "$items"
+            fi
           }
 
           NOTES_FILE=$(mktemp)
@@ -133,7 +139,9 @@ jobs:
             KNOWN="feat|fix|chore|docs|refactor|perf|style|test|ci|build"
             OTHERS=$(echo "$PRS" | jq -r --arg p "$KNOWN" \
               '.[] | select(.title | test("^(" + $p + ")\\b"; "i") | not) | "- \(.title) (#\(.number))"')
-            [ -n "$OTHERS" ] && printf "## Other Changes\n%s\n" "$OTHERS"
+            if [ -n "$OTHERS" ]; then
+              printf "## Other Changes\n%s\n" "$OTHERS"
+            fi
           } > "$NOTES_FILE"
 
           gh release create "$VERSION" \


### PR DESCRIPTION
## Summary
- `generate_section` used `[ -n "$items" ] && printf ...` which returns exit code 1 when no PRs match a category
- GitHub Actions runs bash with `set -eo pipefail` by default, so that non-zero exit kills the script immediately
- Replaced `&&` with `if/fi` so the function always returns 0 regardless of whether any items were found

## Test plan
- [ ] Merge a release PR with at least one category of commits absent (e.g. no `fix:` PRs) and verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)