### PR TITLE
fix: prevent set -e from killing release workflow on empty PR categories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
             local items
             items=$(echo "$PRS" | jq -r --arg p "$prefix" \
               '.[] | select(.title | test("^" + $p + "\\b"; "i")) | "- \(.title) (#\(.number))"')
-            [ -n "$items" ] && printf "## %s\n%s\n\n" "$heading" "$items"
+            if [ -n "$items" ]; then
+              printf "## %s\n%s\n\n" "$heading" "$items"
+            fi
           }
 
           NOTES_FILE=$(mktemp)
@@ -67,7 +69,9 @@ jobs:
             KNOWN="feat|fix|chore|docs|refactor|perf|style|test|ci|build"
             OTHERS=$(echo "$PRS" | jq -r --arg p "$KNOWN" \
               '.[] | select(.title | test("^(" + $p + ")\\b"; "i") | not) | "- \(.title) (#\(.number))"')
-            [ -n "$OTHERS" ] && printf "## Other Changes\n%s\n" "$OTHERS"
+            if [ -n "$OTHERS" ]; then
+              printf "## Other Changes\n%s\n" "$OTHERS"
+            fi
           } > "$NOTES_FILE"
 
           gh release create "$VERSION" \
@@ -114,7 +118,9 @@ jobs:
             local items
             items=$(echo "$PRS" | jq -r --arg p "$prefix" \
               '.[] | select(.title | test("^" + $p + "\\b"; "i")) | "- \(.title) (#\(.number))"')
-            [ -n "$items" ] && printf "## %s\n%s\n\n" "$heading" "$items"
+            if [ -n "$items" ]; then
+              printf "## %s\n%s\n\n" "$heading" "$items"
+            fi
           }
 
           NOTES_FILE=$(mktemp)
@@ -133,7 +139,9 @@ jobs:
             KNOWN="feat|fix|chore|docs|refactor|perf|style|test|ci|build"
             OTHERS=$(echo "$PRS" | jq -r --arg p "$KNOWN" \
               '.[] | select(.title | test("^(" + $p + ")\\b"; "i") | not) | "- \(.title) (#\(.number))"')
-            [ -n "$OTHERS" ] && printf "## Other Changes\n%s\n" "$OTHERS"
+            if [ -n "$OTHERS" ]; then
+              printf "## Other Changes\n%s\n" "$OTHERS"
+            fi
           } > "$NOTES_FILE"
 
           gh release create "$VERSION" \


### PR DESCRIPTION
When no PRs match a section prefix, generate_section returned exit code 1 due to the && short-circuit, which bash's set -eo pipefail (GitHub Actions default) treated as a fatal error. Replaced && with if/fi to always return 0.