### PR TITLE
feat: add workflow_dispatch trigger to manually resend release email

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to resend release notes for (e.g. v1.0.0)'
+        required: true
 
 permissions:
   contents: write
@@ -179,6 +184,34 @@ jobs:
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: "Juno ${{ steps.version.outputs.version }} released"
+          to: ${{ vars.RELEASE_RECIPIENTS }}
+          from: Juno <${{ secrets.MAIL_USERNAME }}>
+          body: ${{ steps.notes.outputs.body }}
+
+  notify-manual:
+    name: Email release notes (manual)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Fetch release notes
+        id: notes
+        run: |
+          BODY=$(gh api repos/${{ github.repository }}/releases/tags/${{ inputs.version }} --jq '.body')
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "Juno ${{ inputs.version }} released"
           to: ${{ vars.RELEASE_RECIPIENTS }}
           from: Juno <${{ secrets.MAIL_USERNAME }}>
           body: ${{ steps.notes.outputs.body }}


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` trigger with a `version` input (e.g. `v1.0.0`)
- Adds a `notify-manual` job that fetches the release notes for that tag and sends the email
- Allows resending release emails from the GitHub Actions UI without re-running a release

## Test plan
- [ ] Go to **Actions → Release → Run workflow**, enter a version tag, and verify the email is received

🤖 Generated with [Claude Code](https://claude.ai/claude-code)